### PR TITLE
Cw algo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,14 @@
     <version>3.5</version>
 </dependency>
 
-<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
+<dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-collections4</artifactId>
+    <version>4.1</version>
+</dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
 <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-api</artifactId>

--- a/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TransactionViewModel.java
@@ -438,4 +438,21 @@ public class TransactionViewModel {
     public String getSender() {
         return transaction.sender;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TransactionViewModel other = (TransactionViewModel) o;
+        return Objects.equals(getHash(), other.getHash());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getHash());
+    }
 }

--- a/src/main/java/com/iota/iri/model/Hash.java
+++ b/src/main/java/com/iota/iri/model/Hash.java
@@ -7,6 +7,7 @@ import com.iota.iri.storage.Indexable;
 import com.iota.iri.utils.Converter;
 
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 public class Hash implements Serializable, Indexable {
@@ -15,6 +16,7 @@ public class Hash implements Serializable, Indexable {
     public static final int SIZE_IN_BYTES = 49;
 
     public static final Hash NULL_HASH = new Hash(new int[Curl.HASH_LENGTH]);
+    public static final int SUBHASH_LENGTH = 16;
 
     private byte[] bytes;
     private int[] trits;
@@ -123,6 +125,16 @@ public class Hash implements Serializable, Indexable {
         this.bytes = new byte[SIZE_IN_BYTES];
         System.arraycopy(bytes, offset, this.bytes, 0, size - offset > bytes.length ? bytes.length-offset: size);
         hashCode = Arrays.hashCode(this.bytes);
+    }
+
+    /**
+     * Used to create low-memory index keys.
+     *
+     * @return a {@link ByteBuffer} that holds a subarray of {@link #bytes()}
+     * that has a size of {@value #SUBHASH_LENGTH}
+     */
+    public ByteBuffer getSubHash() {
+        return ByteBuffer.wrap(Arrays.copyOf(bytes(), SUBHASH_LENGTH));
     }
 
     @Override

--- a/src/main/java/com/iota/iri/model/Hash.java
+++ b/src/main/java/com/iota/iri/model/Hash.java
@@ -16,7 +16,6 @@ public class Hash implements Serializable, Indexable {
     public static final int SIZE_IN_BYTES = 49;
 
     public static final Hash NULL_HASH = new Hash(new int[Curl.HASH_LENGTH]);
-    public static final int SUBHASH_LENGTH = 16;
 
     private byte[] bytes;
     private int[] trits;
@@ -125,16 +124,6 @@ public class Hash implements Serializable, Indexable {
         this.bytes = new byte[SIZE_IN_BYTES];
         System.arraycopy(bytes, offset, this.bytes, 0, size - offset > bytes.length ? bytes.length-offset: size);
         hashCode = Arrays.hashCode(this.bytes);
-    }
-
-    /**
-     * Used to create low-memory index keys.
-     *
-     * @return a {@link ByteBuffer} that holds a subarray of {@link #bytes()}
-     * that has a size of {@value #SUBHASH_LENGTH}
-     */
-    public ByteBuffer getSubHash() {
-        return ByteBuffer.wrap(Arrays.copyOf(bytes(), SUBHASH_LENGTH));
     }
 
     @Override

--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -3,18 +3,25 @@ package com.iota.iri.service;
 import java.util.*;
 
 import com.iota.iri.LedgerValidator;
-import com.iota.iri.Snapshot;
+import com.iota.iri.Milestone;
 import com.iota.iri.TransactionValidator;
+import com.iota.iri.controllers.ApproveeViewModel;
+import com.iota.iri.controllers.MilestoneViewModel;
+import com.iota.iri.controllers.TipsViewModel;
+import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
-import com.iota.iri.controllers.*;
 import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.collections.BoundedSetValuedHashMap;
 import com.iota.iri.zmq.MessageQ;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.multimap.AbstractSetValuedMap;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.iota.iri.Milestone;
-
 public class TipsManager {
+
+    public static final int MAX_ANCESTORS_SIZE = 10000;
 
     private final Logger log = LoggerFactory.getLogger(TipsManager.class);
     private final Tangle tangle;
@@ -109,15 +116,15 @@ public class TipsManager {
         if(milestone.latestSolidSubtangleMilestoneIndex > Milestone.MILESTONE_START_INDEX ||
                 milestone.latestMilestoneIndex == Milestone.MILESTONE_START_INDEX) {
 
-            Map<Hash, Long> ratings = new HashMap<>();
             Set<Hash> analyzedTips = new HashSet<>();
             Set<Hash> maxDepthOk = new HashSet<>();
             try {
                 Hash tip = entryPoint(reference, extraTip, depth);
-                serialUpdateRatings(visitedHashes, tip, ratings, analyzedTips, extraTip);
+                Map<Hash, Integer> cumulativeWeights = calculateCumulativeWeight(visitedHashes, tip,
+                        extraTip != null, new HashSet<>());
                 analyzedTips.clear();
                 if (ledgerValidator.updateDiff(visitedHashes, diff, tip)) {
-                    return markovChainMonteCarlo(visitedHashes, diff, tip, extraTip, ratings, iterations, milestone.latestSolidSubtangleMilestoneIndex - depth * 2, maxDepthOk, seed);
+                    return markovChainMonteCarlo(visitedHashes, diff, tip, extraTip, cumulativeWeights, iterations, milestone.latestSolidSubtangleMilestoneIndex - depth * 2, maxDepthOk, seed);
                 } else {
                     throw new RuntimeException("starting tip failed consistency check: " + tip.toString());
                 }
@@ -149,11 +156,13 @@ public class TipsManager {
         return milestone.latestSolidSubtangleMilestone;
     }
 
-    Hash markovChainMonteCarlo(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, final Hash tip, final Hash extraTip, final Map<Hash, Long> ratings, final int iterations, final int maxDepth, final Set<Hash> maxDepthOk, final Random seed) throws Exception {
+    Hash markovChainMonteCarlo(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, Hash tip, Hash extraTip, Map<Hash, Integer> cumulativeWeight,
+            int iterations, int maxDepth, Set<Hash> maxDepthOk, Random seed) throws Exception {
         Map<Hash, Integer> monteCarloIntegrations = new HashMap<>();
         Hash tail;
         for(int i = iterations; i-- > 0; ) {
-            tail = randomWalk(visitedHashes, diff, tip, extraTip, ratings, maxDepth, maxDepthOk, seed);
+            tail = randomWalk(visitedHashes, diff, tip, extraTip, cumulativeWeight,
+                    maxDepth, maxDepthOk, seed);
             if(monteCarloIntegrations.containsKey(tail)) {
                 monteCarloIntegrations.put(tail, monteCarloIntegrations.get(tail) + 1);
             } else {
@@ -173,7 +182,25 @@ public class TipsManager {
         }).map(Map.Entry::getKey).orElse(null);
     }
 
-    Hash randomWalk(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, final Hash start, final Hash extraTip, final Map<Hash, Long> ratings, final int maxDepth, final Set<Hash> maxDepthOk, Random rnd) throws Exception {
+    /**
+     * Performs a walk from {@code start} until you reach a tip or {@code extraTip}. The path depends of the values
+     * of transaction weights given in {@code cumulativeWeights}. If a tx weight is missing, then calculate it on
+     * the fly.
+     *
+     * @param visitedHashes hashes of transactions that were validated and their weights can be disregarded when we have
+     *                      {@code extraTip} is not {@code null}.
+     * @param diff map of address to change in balance since last snapshot.
+     * @param start hash of the transaction that starts the walk.
+     * @param extraTip an extra ending point for the walk. If not null the walk will ignore the weights of
+     * {@code visitedHashes}.
+     * @param cumulativeWeights maps transaction hashes to weights. Missing data is computed by this method.
+     * @param maxDepth the transactions we are traversing may not be below this depth measured in number of snapshots.
+     * @param maxDepthOk transaction hashes that we know are not below {@code maxDepth}
+     * @param rnd generates random doubles to make the walk less deterministic
+     * @return a tip's hash
+     * @throws Exception
+     */
+    Hash randomWalk(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, final Hash start, final Hash extraTip, final Map<Hash, Integer> cumulativeWeights, final int maxDepth, final Set<Hash> maxDepthOk, Random rnd) throws Exception {
         Hash tip = start, tail = tip;
         Hash[] tips;
         Set<Hash> tipSet;
@@ -232,17 +259,18 @@ public class TipsManager {
             } else {
                 // walk to the next approver
                 tips = tipSet.toArray(new Hash[tipSet.size()]);
-                if (!ratings.containsKey(tip)) {
-                    serialUpdateRatings(myApprovedHashes, tip, ratings, analyzedTips, extraTip);
+                if (!cumulativeWeights.containsKey(tip)) {
+                    cumulativeWeights.putAll(calculateCumulativeWeight(myApprovedHashes, tip, extraTip != null,
+                            analyzedTips));
                     analyzedTips.clear();
                 }
 
                 walkRatings = new double[tips.length];
                 double maxRating = 0;
-                long tipRating = ratings.get(tip);
+                long tipRating = cumulativeWeights.get(tip);
                 for (int i = 0; i < tips.length; i++) {
                     //transition probability = ((Hx-Hy)^-3)/maxRating
-                    walkRatings[i] = Math.pow(tipRating - ratings.getOrDefault(tips[i],0L), -3);
+                    walkRatings[i] = Math.pow(tipRating - cumulativeWeights.getOrDefault(tips[i],0), -3);
                     maxRating += walkRatings[i];
                 }
                 ratingWeight = rnd.nextDouble() * maxRating;
@@ -272,70 +300,135 @@ public class TipsManager {
         return a+b;
     }
 
-    void serialUpdateRatings(final Set<Hash> visitedHashes, final Hash txHash, final Map<Hash, Long> ratings, final Set<Hash> analyzedTips, final Hash extraTip) throws Exception {
-        Stack<Hash> hashesToRate = new Stack<>();
-        hashesToRate.push(txHash);
-        Hash currentHash;
-        boolean addedBack;
-        while(!hashesToRate.empty()) {
-            currentHash = hashesToRate.pop();
-            TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, currentHash);
-            addedBack = false;
-            Set<Hash> approvers = transactionViewModel.getApprovers(tangle).getHashes();
-            for(Hash approver : approvers) {
-                if(ratings.get(approver) == null && !approver.equals(currentHash)) {
-                    if(!addedBack) {
-                        addedBack = true;
-                        hashesToRate.push(currentHash);
+    /**
+     * Updates the cumulative weight of txs.
+     * A cumulative weight of each tx is 1 + the number of ancestors it has.
+     *
+     * See https://github.com/alongalky/iota-docs/blob/master/cumulative.md
+     *
+     *
+     * @param myApprovedHashes the current hashes of the snapshot at the time of calculation
+     * @param currentTxHash the transaction from where the analysis starts
+     * @param confirmLeftBehind if true attempt to give more weight to previously
+     *                          unconfirmed txs
+     * @throws Exception if there is a problem accessing the db
+     */
+    Map<Hash, Integer> calculateCumulativeWeight(Set<Hash> myApprovedHashes, Hash currentTxHash, boolean confirmLeftBehind,
+            Set<Hash> analyzedTips) throws Exception {
+        Collection<TransactionViewModel> txsToRate = sortTransactionsInTopologicalOrder(currentTxHash);
+        return calculateCwInOrder(txsToRate, myApprovedHashes, confirmLeftBehind, analyzedTips);
+    }
+
+    private Set<TransactionViewModel> sortTransactionsInTopologicalOrder(Hash startTx) throws Exception {
+        Set<TransactionViewModel> sortedTxs = new LinkedHashSet<>();
+        Set<TransactionViewModel> temporary = new HashSet<>();
+        Deque<TransactionViewModel> stack = new ArrayDeque<>();
+        Map<TransactionViewModel, Collection<TransactionViewModel>> txToDirectApprovers = new HashMap<>();
+
+        stack.push(TransactionViewModel.fromHash(tangle, startTx));
+        while (CollectionUtils.isNotEmpty(stack)) {
+            TransactionViewModel tx = stack.peek();
+            if (!sortedTxs.contains(tx)) {
+                Collection<TransactionViewModel> appHashes = getTxDirectApproversHashes(tx, txToDirectApprovers);
+                if (CollectionUtils.isNotEmpty(appHashes)) {
+                    TransactionViewModel txApp = getAndRemoveApprover(appHashes);
+                    if (!temporary.add(txApp)) {
+                        throw new IllegalStateException("A circle was found in a subtangle on hash: " + txApp.getHash());
                     }
-                    hashesToRate.push(approver);
+                    stack.push(txApp);
+                    continue;
                 }
             }
-            if(!addedBack && analyzedTips.add(currentHash)) {
-                long rating = (extraTip != null && visitedHashes.contains(currentHash)? 0: 1) + approvers.stream().map(ratings::get).filter(Objects::nonNull)
-                        .reduce((a, b) -> capSum(a,b, Long.MAX_VALUE/2)).orElse(0L);
-                ratings.put(currentHash, rating);
+            else {
+                temporary.remove(stack.pop());
+                continue;
             }
+            sortedTxs.add(tx);
         }
+
+        return sortedTxs;
     }
 
-    Set<Hash> updateHashRatings(Hash txHash, Map<Hash, Set<Hash>> ratings, Set<Hash> analyzedTips) throws Exception {
-        Set<Hash> rating;
-        if(analyzedTips.add(txHash)) {
-            TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, txHash);
-            rating = new HashSet<>(Collections.singleton(txHash));
-            Set<Hash> approverHashes = transactionViewModel.getApprovers(tangle).getHashes();
-            for(Hash approver : approverHashes) {
-                rating.addAll(updateHashRatings(approver, ratings, analyzedTips));
-            }
-            ratings.put(txHash, rating);
-        } else {
-            if(ratings.containsKey(txHash)) {
-                rating = ratings.get(txHash);
-            } else {
-                rating = new HashSet<>();
-            }
-        }
-        return rating;
+    private TransactionViewModel getAndRemoveApprover(Collection<TransactionViewModel> appHashes) {
+        Iterator<TransactionViewModel> hashIterator = appHashes.iterator();
+        TransactionViewModel txApp = hashIterator.next();
+        hashIterator.remove();
+        return txApp;
     }
 
-    long recursiveUpdateRatings(Hash txHash, Map<Hash, Long> ratings, Set<Hash> analyzedTips) throws Exception {
-        long rating = 1;
-        if(analyzedTips.add(txHash)) {
-            TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, txHash);
-            Set<Hash> approverHashes = transactionViewModel.getApprovers(tangle).getHashes();
-            for(Hash approver : approverHashes) {
-                rating = capSum(rating, recursiveUpdateRatings(approver, ratings, analyzedTips), Long.MAX_VALUE/2);
+    private Collection<TransactionViewModel> getTxDirectApproversHashes(TransactionViewModel tx,
+            Map<TransactionViewModel, Collection<TransactionViewModel>> txToDirectApprovers) throws Exception {
+        Collection<TransactionViewModel> txApprovers = txToDirectApprovers.get(tx);
+        if (txApprovers == null) {
+            ApproveeViewModel approvers = tx.getApprovers(tangle);
+            Collection<Hash> appHashes = CollectionUtils.emptyIfNull(approvers.getHashes());
+            txApprovers = new HashSet<>(appHashes.size());
+            for (Hash appHash : appHashes) {
+                //if not genesis (the tx that confirms itself)
+                if (ObjectUtils.notEqual(Hash.NULL_HASH, appHash)) {
+                    TransactionViewModel txApp = TransactionViewModel.fromHash(tangle, appHash);
+                    txApprovers.add(txApp);
+                }
             }
-            ratings.put(txHash, rating);
-        } else {
-            if(ratings.containsKey(txHash)) {
-                rating = ratings.get(txHash);
-            } else {
-                rating = 0;
-            }
+            txToDirectApprovers.put(tx, txApprovers);
         }
-        return rating;
+        return txApprovers;
+    }
+
+    private Map<Hash, Integer> calculateCwInOrder(Collection<TransactionViewModel> txsToRate,
+            Set<Hash> myApprovedHashes, boolean confirmLeftBehind, Set<Hash> analyzedTips) throws Exception {
+        AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> txToApprovers =
+                new BoundedSetValuedHashMap<>(MAX_ANCESTORS_SIZE);
+        HashMap<Hash, Integer> txToCumulativeWeight = new HashMap<>();
+
+        for (TransactionViewModel transactionViewModel : txsToRate) {
+            if (analyzedTips.add(transactionViewModel.getHash())) {
+                txToCumulativeWeight = updateCw(txToApprovers, txToCumulativeWeight, transactionViewModel, myApprovedHashes,
+                        confirmLeftBehind);
+            }
+            txToApprovers = updateApproversAndReleaseMemory(txToApprovers, transactionViewModel, myApprovedHashes,
+                    confirmLeftBehind);
+        }
+
+        return txToCumulativeWeight;
+    }
+
+
+    private AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> updateApproversAndReleaseMemory(
+            AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> txToApprovers,
+            TransactionViewModel transactionViewModel, Set<Hash> myApprovedHashes, boolean confirmLeftBehind) throws Exception {
+        Set<TransactionViewModel> approvers = txToApprovers.get(transactionViewModel);
+
+        TransactionViewModel trunkTransaction = transactionViewModel.getTrunkTransaction(tangle);
+        txToApprovers.putAll(trunkTransaction, approvers);
+        TransactionViewModel branchTransaction = transactionViewModel.getBranchTransaction(tangle);
+        txToApprovers.putAll(branchTransaction, approvers);
+        if (shouldIncludeTransaction(transactionViewModel, myApprovedHashes, confirmLeftBehind)) {
+            txToApprovers.put(trunkTransaction, transactionViewModel);
+            txToApprovers.put(branchTransaction, transactionViewModel);
+        }
+
+        txToApprovers.remove(transactionViewModel);
+
+        return txToApprovers;
+    }
+
+    private static boolean shouldIncludeTransaction(TransactionViewModel tx, Set<Hash> myApprovedHashes,
+            boolean confirmLeftBehind) {
+        return tx != null
+                && !(confirmLeftBehind && myApprovedHashes.contains(tx.getHash()));
+    }
+
+    private HashMap<Hash, Integer> updateCw(AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> txToApprovers,
+            HashMap<Hash, Integer> txToCumulativeWeight, TransactionViewModel transactionViewModel,
+            Set<Hash> myApprovedHashes, boolean confirmLeftBehind) {
+        Set<TransactionViewModel> approvers = txToApprovers.get(transactionViewModel);
+        int weight = CollectionUtils.emptyIfNull(approvers).size();
+        if (shouldIncludeTransaction(transactionViewModel, myApprovedHashes, confirmLeftBehind)) {
+            ++weight;
+        }
+        txToCumulativeWeight.put(transactionViewModel.getHash(), weight);
+        return txToCumulativeWeight;
     }
 
     public int getMaxDepth() {

--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -9,6 +9,7 @@ import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.IotaUtils;
 import com.iota.iri.utils.SafeUtils;
 import com.iota.iri.utils.collections.impl.BoundedHashSet;
 import com.iota.iri.utils.collections.interfaces.BoundedSet;
@@ -35,6 +36,7 @@ public class TipsManager {
     private final TransactionValidator transactionValidator;
     private final MessageQ messageQ;
 
+    public static final int SUBHASH_LENGTH = 16;
     private int RATING_THRESHOLD = 75; // Must be in [0..100] range
     private boolean shuttingDown = false;
     private int RESCAN_TX_TO_REQUEST_INTERVAL = 750;
@@ -259,7 +261,7 @@ public class TipsManager {
             } else {
                 // walk to the next approver
                 tips = tipSet.toArray(new Hash[tipSet.size()]);
-                if (!cumulativeWeights.containsKey(tip.getSubHash())) {
+                if (!cumulativeWeights.containsKey(IotaUtils.getSubHash(tip, SUBHASH_LENGTH))) {
                     cumulativeWeights.putAll(calculateCumulativeWeight(myApprovedHashes, tip, extraTip != null,
                             analyzedTips));
                     analyzedTips.clear();
@@ -267,10 +269,10 @@ public class TipsManager {
 
                 walkRatings = new double[tips.length];
                 double maxRating = 0;
-                ByteBuffer subHash = tip.getSubHash();
+                ByteBuffer subHash = IotaUtils.getSubHash(tip, SUBHASH_LENGTH);
                 long tipRating = cumulativeWeights.get(subHash);
                 for (int i = 0; i < tips.length; i++) {
-                    subHash = tips[i].getSubHash();
+                    subHash = IotaUtils.getSubHash(tip, SUBHASH_LENGTH);
                     //transition probability = ((Hx-Hy)^-3)/maxRating
                     walkRatings[i] = Math.pow(tipRating - cumulativeWeights.getOrDefault(subHash,0), -3);
                     maxRating += walkRatings[i];
@@ -411,7 +413,7 @@ public class TipsManager {
     private Map<Buffer, Set<Buffer>> updateApproversAndReleaseMemory(
             Map<Buffer, Set<Buffer>> txSubHashToApprovers,
             Hash txHash, Set<Hash> myApprovedHashes, boolean confirmLeftBehind) throws Exception {
-        ByteBuffer txSubHash = txHash.getSubHash();
+        ByteBuffer txSubHash = IotaUtils.getSubHash(txHash, SUBHASH_LENGTH);
         BoundedSet<Buffer> approvers =
                 new BoundedHashSet<>(SetUtils.emptyIfNull(txSubHashToApprovers.get(txSubHash)), MAX_ANCESTORS_SIZE);
 
@@ -421,9 +423,9 @@ public class TipsManager {
 
         TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, txHash);
         Hash trunkHash = transactionViewModel.getTrunkTransactionHash();
-        Buffer trunkSubHash = trunkHash.getSubHash();
+        Buffer trunkSubHash = IotaUtils.getSubHash(trunkHash, SUBHASH_LENGTH);
         Hash branchHash = transactionViewModel.getBranchTransactionHash();
-        Buffer branchSubHash = branchHash.getSubHash();
+        Buffer branchSubHash = IotaUtils.getSubHash(branchHash, SUBHASH_LENGTH);
         if (!approvers.isFull()) {
             Set<Buffer> trunkApprovers = new BoundedHashSet<>(approvers, MAX_ANCESTORS_SIZE);
             trunkApprovers.addAll(CollectionUtils.emptyIfNull(txSubHashToApprovers.get(trunkSubHash)));
@@ -449,7 +451,7 @@ public class TipsManager {
     private Map<Buffer, Integer> updateCw(Map<Buffer, Set<Buffer>> txSubHashToApprovers,
             Map<Buffer, Integer> txToCumulativeWeight, Hash txHash,
             Set<Hash> myApprovedHashes, boolean confirmLeftBehind) {
-        ByteBuffer txSubHash = txHash.getSubHash();
+        ByteBuffer txSubHash = IotaUtils.getSubHash(txHash, SUBHASH_LENGTH);
         Set<Buffer> approvers = txSubHashToApprovers.get(txSubHash);
         int weight = CollectionUtils.emptyIfNull(approvers).size();
         if (shouldIncludeTransaction(txHash, myApprovedHashes, confirmLeftBehind)) {

--- a/src/main/java/com/iota/iri/service/TipsManager.java
+++ b/src/main/java/com/iota/iri/service/TipsManager.java
@@ -1,7 +1,5 @@
 package com.iota.iri.service;
 
-import java.util.*;
-
 import com.iota.iri.LedgerValidator;
 import com.iota.iri.Milestone;
 import com.iota.iri.TransactionValidator;
@@ -11,17 +9,23 @@ import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.storage.Tangle;
-import com.iota.iri.utils.collections.BoundedSetValuedHashMap;
+import com.iota.iri.utils.SafeUtils;
+import com.iota.iri.utils.collections.impl.BoundedHashSet;
+import com.iota.iri.utils.collections.interfaces.BoundedSet;
 import com.iota.iri.zmq.MessageQ;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.multimap.AbstractSetValuedMap;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.*;
+
 public class TipsManager {
 
-    public static final int MAX_ANCESTORS_SIZE = 10000;
+    public static final int MAX_ANCESTORS_SIZE = 1000;
 
     private final Logger log = LoggerFactory.getLogger(TipsManager.class);
     private final Tangle tangle;
@@ -120,7 +124,7 @@ public class TipsManager {
             Set<Hash> maxDepthOk = new HashSet<>();
             try {
                 Hash tip = entryPoint(reference, extraTip, depth);
-                Map<Hash, Integer> cumulativeWeights = calculateCumulativeWeight(visitedHashes, tip,
+                Map<Buffer, Integer> cumulativeWeights = calculateCumulativeWeight(visitedHashes, tip,
                         extraTip != null, new HashSet<>());
                 analyzedTips.clear();
                 if (ledgerValidator.updateDiff(visitedHashes, diff, tip)) {
@@ -156,7 +160,7 @@ public class TipsManager {
         return milestone.latestSolidSubtangleMilestone;
     }
 
-    Hash markovChainMonteCarlo(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, Hash tip, Hash extraTip, Map<Hash, Integer> cumulativeWeight,
+    Hash markovChainMonteCarlo(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, Hash tip, Hash extraTip, Map<Buffer, Integer> cumulativeWeight,
             int iterations, int maxDepth, Set<Hash> maxDepthOk, Random seed) throws Exception {
         Map<Hash, Integer> monteCarloIntegrations = new HashMap<>();
         Hash tail;
@@ -200,7 +204,7 @@ public class TipsManager {
      * @return a tip's hash
      * @throws Exception
      */
-    Hash randomWalk(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, final Hash start, final Hash extraTip, final Map<Hash, Integer> cumulativeWeights, final int maxDepth, final Set<Hash> maxDepthOk, Random rnd) throws Exception {
+    Hash randomWalk(final Set<Hash> visitedHashes, final Map<Hash, Long> diff, final Hash start, final Hash extraTip, final Map<Buffer, Integer> cumulativeWeights, final int maxDepth, final Set<Hash> maxDepthOk, Random rnd) throws Exception {
         Hash tip = start, tail = tip;
         Hash[] tips;
         Set<Hash> tipSet;
@@ -210,10 +214,6 @@ public class TipsManager {
         int approverIndex;
         double ratingWeight;
         double[] walkRatings;
-        List<Hash> extraTipList = null;
-        if (extraTip != null) {
-            extraTipList = Collections.singletonList(extraTip);
-        }
         Map<Hash, Long> myDiff = new HashMap<>(diff);
         Set<Hash> myApprovedHashes = new HashSet<>(visitedHashes);
 
@@ -259,7 +259,7 @@ public class TipsManager {
             } else {
                 // walk to the next approver
                 tips = tipSet.toArray(new Hash[tipSet.size()]);
-                if (!cumulativeWeights.containsKey(tip)) {
+                if (!cumulativeWeights.containsKey(tip.getSubHash())) {
                     cumulativeWeights.putAll(calculateCumulativeWeight(myApprovedHashes, tip, extraTip != null,
                             analyzedTips));
                     analyzedTips.clear();
@@ -267,10 +267,12 @@ public class TipsManager {
 
                 walkRatings = new double[tips.length];
                 double maxRating = 0;
-                long tipRating = cumulativeWeights.get(tip);
+                ByteBuffer subHash = tip.getSubHash();
+                long tipRating = cumulativeWeights.get(subHash);
                 for (int i = 0; i < tips.length; i++) {
+                    subHash = tips[i].getSubHash();
                     //transition probability = ((Hx-Hy)^-3)/maxRating
-                    walkRatings[i] = Math.pow(tipRating - cumulativeWeights.getOrDefault(tips[i],0), -3);
+                    walkRatings[i] = Math.pow(tipRating - cumulativeWeights.getOrDefault(subHash,0), -3);
                     maxRating += walkRatings[i];
                 }
                 ratingWeight = rnd.nextDouble() * maxRating;
@@ -313,121 +315,147 @@ public class TipsManager {
      *                          unconfirmed txs
      * @throws Exception if there is a problem accessing the db
      */
-    Map<Hash, Integer> calculateCumulativeWeight(Set<Hash> myApprovedHashes, Hash currentTxHash, boolean confirmLeftBehind,
+    Map<Buffer, Integer> calculateCumulativeWeight(Set<Hash> myApprovedHashes, Hash currentTxHash, boolean confirmLeftBehind,
             Set<Hash> analyzedTips) throws Exception {
-        Collection<TransactionViewModel> txsToRate = sortTransactionsInTopologicalOrder(currentTxHash);
-        return calculateCwInOrder(txsToRate, myApprovedHashes, confirmLeftBehind, analyzedTips);
+        log.info("Start calculating cw starting with tx hash {}", currentTxHash);
+        log.debug("Start topological sort");
+        long start = System.currentTimeMillis();
+        LinkedHashSet<Hash> txHashesToRate = sortTransactionsInTopologicalOrder(currentTxHash);
+        log.debug("Subtangle size: {}", txHashesToRate.size());
+        log.debug("Topological sort done. Start traversing on txs in order and calculate weight");
+        Map<Buffer, Integer> cumulativeWeights = calculateCwInOrder(txHashesToRate, myApprovedHashes, confirmLeftBehind,
+                analyzedTips);
+        log.debug("Cumulative weights calculation done in {} ms", System.currentTimeMillis() - start);
+        return cumulativeWeights;
     }
 
-    private Set<TransactionViewModel> sortTransactionsInTopologicalOrder(Hash startTx) throws Exception {
-        Set<TransactionViewModel> sortedTxs = new LinkedHashSet<>();
-        Set<TransactionViewModel> temporary = new HashSet<>();
-        Deque<TransactionViewModel> stack = new ArrayDeque<>();
-        Map<TransactionViewModel, Collection<TransactionViewModel>> txToDirectApprovers = new HashMap<>();
+    private LinkedHashSet<Hash>  sortTransactionsInTopologicalOrder(Hash startTx) throws Exception {
+        LinkedHashSet<Hash> sortedTxs = new LinkedHashSet<>();
+        Set<Hash> temporary = new HashSet<>();
+        Deque<Hash> stack = new ArrayDeque<>();
+        Map<Hash, Collection<Hash>> txToDirectApprovers = new HashMap<>();
 
-        stack.push(TransactionViewModel.fromHash(tangle, startTx));
+        stack.push(startTx);
         while (CollectionUtils.isNotEmpty(stack)) {
-            TransactionViewModel tx = stack.peek();
-            if (!sortedTxs.contains(tx)) {
-                Collection<TransactionViewModel> appHashes = getTxDirectApproversHashes(tx, txToDirectApprovers);
+            Hash txHash = stack.peek();
+            if (!sortedTxs.contains(txHash)) {
+                Collection<Hash> appHashes = getTxDirectApproversHashes(txHash, txToDirectApprovers);
                 if (CollectionUtils.isNotEmpty(appHashes)) {
-                    TransactionViewModel txApp = getAndRemoveApprover(appHashes);
+                    Hash txApp = getAndRemoveApprover(appHashes);
                     if (!temporary.add(txApp)) {
-                        throw new IllegalStateException("A circle was found in a subtangle on hash: " + txApp.getHash());
+                        throw new IllegalStateException("A circle or a collision was found in a subtangle on hash: "
+                                + txApp);
                     }
                     stack.push(txApp);
                     continue;
                 }
             }
             else {
-                temporary.remove(stack.pop());
+                txHash = stack.pop();
+                temporary.remove(txHash);
                 continue;
             }
-            sortedTxs.add(tx);
+            sortedTxs.add(txHash);
         }
 
         return sortedTxs;
     }
 
-    private TransactionViewModel getAndRemoveApprover(Collection<TransactionViewModel> appHashes) {
-        Iterator<TransactionViewModel> hashIterator = appHashes.iterator();
-        TransactionViewModel txApp = hashIterator.next();
+    private Hash getAndRemoveApprover(Collection<Hash> appHashes) {
+        Iterator<Hash> hashIterator = appHashes.iterator();
+        Hash txApp = hashIterator.next();
         hashIterator.remove();
         return txApp;
     }
 
-    private Collection<TransactionViewModel> getTxDirectApproversHashes(TransactionViewModel tx,
-            Map<TransactionViewModel, Collection<TransactionViewModel>> txToDirectApprovers) throws Exception {
-        Collection<TransactionViewModel> txApprovers = txToDirectApprovers.get(tx);
+    private Collection<Hash> getTxDirectApproversHashes(Hash txHash,
+            Map<Hash, Collection<Hash>> txToDirectApprovers) throws Exception {
+        Collection<Hash> txApprovers = txToDirectApprovers.get(txHash);
         if (txApprovers == null) {
-            ApproveeViewModel approvers = tx.getApprovers(tangle);
+            ApproveeViewModel approvers = TransactionViewModel.fromHash(tangle, txHash).getApprovers(tangle);
             Collection<Hash> appHashes = CollectionUtils.emptyIfNull(approvers.getHashes());
             txApprovers = new HashSet<>(appHashes.size());
             for (Hash appHash : appHashes) {
                 //if not genesis (the tx that confirms itself)
                 if (ObjectUtils.notEqual(Hash.NULL_HASH, appHash)) {
-                    TransactionViewModel txApp = TransactionViewModel.fromHash(tangle, appHash);
-                    txApprovers.add(txApp);
+                    txApprovers.add(appHash);
                 }
             }
-            txToDirectApprovers.put(tx, txApprovers);
+            txToDirectApprovers.put(txHash, txApprovers);
         }
         return txApprovers;
     }
 
-    private Map<Hash, Integer> calculateCwInOrder(Collection<TransactionViewModel> txsToRate,
+    //must specify using LinkedHashSet since Java has no interface that guarantees uniqueness and insertion order
+    private Map<Buffer, Integer> calculateCwInOrder(LinkedHashSet<Hash> txsToRate,
             Set<Hash> myApprovedHashes, boolean confirmLeftBehind, Set<Hash> analyzedTips) throws Exception {
-        AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> txToApprovers =
-                new BoundedSetValuedHashMap<>(MAX_ANCESTORS_SIZE);
-        HashMap<Hash, Integer> txToCumulativeWeight = new HashMap<>();
+        Map<Buffer, Set<Buffer>> txSubHashToApprovers = new HashMap<>();
+        Map<Buffer, Integer> txSubHashToCumulativeWeight = new HashMap<>();
 
-        for (TransactionViewModel transactionViewModel : txsToRate) {
-            if (analyzedTips.add(transactionViewModel.getHash())) {
-                txToCumulativeWeight = updateCw(txToApprovers, txToCumulativeWeight, transactionViewModel, myApprovedHashes,
-                        confirmLeftBehind);
+        Iterator<Hash> txHashIterator = txsToRate.iterator();
+        while (txHashIterator.hasNext()) {
+            Hash txHash = txHashIterator.next();
+            if (analyzedTips.add(txHash)) {
+                txSubHashToCumulativeWeight = updateCw(txSubHashToApprovers, txSubHashToCumulativeWeight, txHash,
+                        myApprovedHashes, confirmLeftBehind);
             }
-            txToApprovers = updateApproversAndReleaseMemory(txToApprovers, transactionViewModel, myApprovedHashes,
+            txSubHashToApprovers = updateApproversAndReleaseMemory(txSubHashToApprovers, txHash, myApprovedHashes,
                     confirmLeftBehind);
+            txHashIterator.remove();
         }
 
-        return txToCumulativeWeight;
+        return txSubHashToCumulativeWeight;
     }
 
 
-    private AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> updateApproversAndReleaseMemory(
-            AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> txToApprovers,
-            TransactionViewModel transactionViewModel, Set<Hash> myApprovedHashes, boolean confirmLeftBehind) throws Exception {
-        Set<TransactionViewModel> approvers = txToApprovers.get(transactionViewModel);
+    private Map<Buffer, Set<Buffer>> updateApproversAndReleaseMemory(
+            Map<Buffer, Set<Buffer>> txSubHashToApprovers,
+            Hash txHash, Set<Hash> myApprovedHashes, boolean confirmLeftBehind) throws Exception {
+        ByteBuffer txSubHash = txHash.getSubHash();
+        BoundedSet<Buffer> approvers =
+                new BoundedHashSet<>(SetUtils.emptyIfNull(txSubHashToApprovers.get(txSubHash)), MAX_ANCESTORS_SIZE);
 
-        TransactionViewModel trunkTransaction = transactionViewModel.getTrunkTransaction(tangle);
-        txToApprovers.putAll(trunkTransaction, approvers);
-        TransactionViewModel branchTransaction = transactionViewModel.getBranchTransaction(tangle);
-        txToApprovers.putAll(branchTransaction, approvers);
-        if (shouldIncludeTransaction(transactionViewModel, myApprovedHashes, confirmLeftBehind)) {
-            txToApprovers.put(trunkTransaction, transactionViewModel);
-            txToApprovers.put(branchTransaction, transactionViewModel);
+        if (shouldIncludeTransaction(txHash, myApprovedHashes, confirmLeftBehind)) {
+            approvers.add(txSubHash);
         }
 
-        txToApprovers.remove(transactionViewModel);
+        TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, txHash);
+        Hash trunkHash = transactionViewModel.getTrunkTransactionHash();
+        Buffer trunkSubHash = trunkHash.getSubHash();
+        Hash branchHash = transactionViewModel.getBranchTransactionHash();
+        Buffer branchSubHash = branchHash.getSubHash();
+        if (!approvers.isFull()) {
+            Set<Buffer> trunkApprovers = new BoundedHashSet<>(approvers, MAX_ANCESTORS_SIZE);
+            trunkApprovers.addAll(CollectionUtils.emptyIfNull(txSubHashToApprovers.get(trunkSubHash)));
+            Set<Buffer> branchApprovers = new BoundedHashSet<>(approvers, MAX_ANCESTORS_SIZE);
+            branchApprovers.addAll(CollectionUtils.emptyIfNull(txSubHashToApprovers.get(branchSubHash)));
+            txSubHashToApprovers.put(trunkSubHash, trunkApprovers);
+            txSubHashToApprovers.put(branchSubHash, branchApprovers);
+        }
+        else {
+            txSubHashToApprovers.put(trunkSubHash, approvers);
+            txSubHashToApprovers.put(branchSubHash, approvers);
+        }
+        txSubHashToApprovers.remove(txSubHash);
 
-        return txToApprovers;
+        return txSubHashToApprovers;
     }
 
-    private static boolean shouldIncludeTransaction(TransactionViewModel tx, Set<Hash> myApprovedHashes,
+    private static boolean shouldIncludeTransaction(Hash txHash, Set<Hash> myApprovedSubHashes,
             boolean confirmLeftBehind) {
-        return tx != null
-                && !(confirmLeftBehind && myApprovedHashes.contains(tx.getHash()));
+        return !confirmLeftBehind || !SafeUtils.isContaining(myApprovedSubHashes, txHash);
     }
 
-    private HashMap<Hash, Integer> updateCw(AbstractSetValuedMap<TransactionViewModel, TransactionViewModel> txToApprovers,
-            HashMap<Hash, Integer> txToCumulativeWeight, TransactionViewModel transactionViewModel,
+    private Map<Buffer, Integer> updateCw(Map<Buffer, Set<Buffer>> txSubHashToApprovers,
+            Map<Buffer, Integer> txToCumulativeWeight, Hash txHash,
             Set<Hash> myApprovedHashes, boolean confirmLeftBehind) {
-        Set<TransactionViewModel> approvers = txToApprovers.get(transactionViewModel);
+        ByteBuffer txSubHash = txHash.getSubHash();
+        Set<Buffer> approvers = txSubHashToApprovers.get(txSubHash);
         int weight = CollectionUtils.emptyIfNull(approvers).size();
-        if (shouldIncludeTransaction(transactionViewModel, myApprovedHashes, confirmLeftBehind)) {
+        if (shouldIncludeTransaction(txHash, myApprovedHashes, confirmLeftBehind)) {
             ++weight;
         }
-        txToCumulativeWeight.put(transactionViewModel.getHash(), weight);
+        txToCumulativeWeight.put(txSubHash, weight);
         return txToCumulativeWeight;
     }
 

--- a/src/main/java/com/iota/iri/utils/IotaUtils.java
+++ b/src/main/java/com/iota/iri/utils/IotaUtils.java
@@ -1,0 +1,24 @@
+package com.iota.iri.utils;
+
+import com.iota.iri.model.Hash;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+public class IotaUtils {
+    /**
+     * Used to create low-memory index keys.
+     *
+     * @param hash the hash we create the key from
+     * @param length the length of the desired subhash
+     * @return a {@link ByteBuffer} that holds a subarray of {@link Hash#bytes()}
+     * that has the specified {@code length}
+     */
+    public static ByteBuffer getSubHash(Hash hash, int length) {
+        if (hash == null) {
+            return null;
+        }
+
+        return ByteBuffer.wrap(Arrays.copyOf(hash.bytes(), length));
+    }
+}

--- a/src/main/java/com/iota/iri/utils/SafeUtils.java
+++ b/src/main/java/com/iota/iri/utils/SafeUtils.java
@@ -1,0 +1,15 @@
+package com.iota.iri.utils;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+
+/**
+ * Null safe utils
+ */
+public class SafeUtils {
+
+    public static <T> boolean isContaining(Collection<T> collection, T element) {
+        return collection != null && element != null && collection.contains(element);
+    }
+}

--- a/src/main/java/com/iota/iri/utils/SafeUtils.java
+++ b/src/main/java/com/iota/iri/utils/SafeUtils.java
@@ -1,7 +1,6 @@
 package com.iota.iri.utils;
 
 import java.util.Collection;
-import java.util.stream.Stream;
 
 
 /**

--- a/src/main/java/com/iota/iri/utils/collections/impl/BoundedHashSet.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/BoundedHashSet.java
@@ -1,0 +1,94 @@
+package com.iota.iri.utils.collections.impl;
+
+import com.iota.iri.utils.collections.interfaces.BoundedSet;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+
+/**
+ * A set that doesn't allow to add elements to it once it is full
+ *
+ * @param <E> the type parameter
+ */
+public class BoundedHashSet<E> extends HashSet<E> implements BoundedSet<E>{
+    final private int maxSize;
+
+    /**
+     * Instantiates a new Bounded hash set.
+     *
+     * @param initialCapacity the initial capacity
+     * @param loadFactor      the load factor of the hashmap
+     * @param maxSize         the max size
+     */
+    public BoundedHashSet(int initialCapacity, float loadFactor, int maxSize) {
+        super(initialCapacity, loadFactor);
+        this.maxSize = maxSize;
+    }
+
+    /**
+     * Instantiates a new Bounded hash set.
+     *
+     * @param initialCapacity the initial capacity
+     * @param maxSize         the max size
+     */
+    public BoundedHashSet(int initialCapacity, int maxSize) {
+        super(initialCapacity);
+        this.maxSize = maxSize;
+    }
+
+    /**
+     * Instantiates a new Bounded hash set.
+     *
+     * @param maxSize the max size
+     */
+    public BoundedHashSet(int maxSize) {
+        super();
+        this.maxSize = maxSize;
+    }
+
+    /**
+     * Instantiates a new Bounded hash set.
+     *
+     * @param c       the collection from which you create the set from
+     * @param maxSize the max size
+     * @throws NullPointerException if the specified collection is null
+     */
+    public BoundedHashSet(Collection<? extends E> c, int maxSize) {
+        this(maxSize);
+        c = c.stream()
+                .limit(maxSize)
+                .collect(Collectors.toSet());
+        this.addAll(c);
+    }
+
+    @Override
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    @Override
+    public boolean add(E e) {
+        if (isFull()) {
+            return false;
+        }
+
+        return super.add(e);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        if (isFull()) {
+            return false;
+        }
+
+        if (!canCollectionBeFullyAdded(c)) {
+            int remainingSize = getMaxSize() - this.size();
+            c = c.stream()
+                    .limit(remainingSize)
+                    .collect(Collectors.toSet());
+        }
+        return super.addAll(c);
+    }
+}

--- a/src/main/java/com/iota/iri/utils/collections/interfaces/BoundedCollection.java
+++ b/src/main/java/com/iota/iri/utils/collections/interfaces/BoundedCollection.java
@@ -1,0 +1,39 @@
+package com.iota.iri.utils.collections.interfaces;
+
+import java.util.Collection;
+
+/**
+ * A collection that can't hold more than {@link #getMaxSize()} elements
+ *
+ * @author galrogo on 08/02/18
+ **/
+public interface BoundedCollection<E> extends Collection<E> {
+
+    /**
+     *
+     * @return the maximal number of elements that the collection cha hold
+     */
+    int getMaxSize();
+
+    /**
+     * @return true if no more elements can be added
+     */
+    default boolean isFull() {
+        return getMaxSize() <= this.size();
+    }
+
+    /**
+     *
+     * @param c collection to be added
+     * @return true only if all the elements in {@code c} can be added to this collection
+     * else return false
+     */
+    default boolean canCollectionBeFullyAdded(Collection<? extends E> c) {
+        if (isFull()) {
+            return false;
+        }
+
+        int remainingSize = getMaxSize() - this.size();
+        return (c.size() <= remainingSize);
+    }
+}

--- a/src/main/java/com/iota/iri/utils/collections/interfaces/BoundedSet.java
+++ b/src/main/java/com/iota/iri/utils/collections/interfaces/BoundedSet.java
@@ -1,0 +1,11 @@
+package com.iota.iri.utils.collections.interfaces;
+
+import java.util.Set;
+
+/**
+ * A set that can't hold more than {@link #getMaxSize()} elements
+ *
+ * @author galrogo on 08/02/18
+ **/
+public interface BoundedSet<E> extends BoundedCollection<E>, Set<E>{
+}

--- a/src/test/java/com/iota/iri/service/TipsManagerTest.java
+++ b/src/test/java/com/iota/iri/service/TipsManagerTest.java
@@ -10,6 +10,7 @@ import com.iota.iri.model.Hash;
 import com.iota.iri.network.TransactionRequester;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import com.iota.iri.utils.IotaUtils;
 import com.iota.iri.zmq.MessageQ;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -95,15 +96,15 @@ public class TipsManagerTest {
                 transaction.getHash(), false, new HashSet<>());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                1, txToCw.get(transaction4.getHash().getSubHash()).intValue());
+                1, txToCw.get(IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                2, txToCw.get(transaction3.getHash().getSubHash()).intValue());
+                2, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(transaction2.getHash().getSubHash()).intValue());
+                3, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                4, txToCw.get(transaction1.getHash().getSubHash()).intValue());
+                4, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                5, txToCw.get(transaction.getHash().getSubHash()).intValue());
+                5, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
     }
 
     @Test
@@ -126,13 +127,16 @@ public class TipsManagerTest {
                 transaction.getHash(), false, new HashSet<>());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                1, txToCw.get(transaction3.getHash().getSubHash()).intValue());
+                1, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH))
+                        .intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                2, txToCw.get(transaction1.getHash().getSubHash()).intValue());
+                2, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH))
+                        .intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                2, txToCw.get(transaction2.getHash().getSubHash()).intValue());
+                2, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH))
+                        .intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                4, txToCw.get(transaction.getHash().getSubHash()).intValue());
+                4, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
     }
 
     @Test
@@ -161,15 +165,15 @@ public class TipsManagerTest {
 
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                1, txToCw.get(transaction4.getHash().getSubHash()).intValue());
+                1, txToCw.get(IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                2, txToCw.get(transaction3.getHash().getSubHash()).intValue());
+                2, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(transaction2.getHash().getSubHash()).intValue());
+                3, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                4, txToCw.get(transaction1.getHash().getSubHash()).intValue());
+                4, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                5, txToCw.get(transaction.getHash().getSubHash()).intValue());
+                5, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
     }
 
     @Test
@@ -206,19 +210,19 @@ public class TipsManagerTest {
                 transaction.getHash(), false, new HashSet<>());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 6),
-                1, txToCw.get(transaction6.getHash().getSubHash()).intValue());
+                1, txToCw.get(IotaUtils.getSubHash(transaction6.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 5),
-                2, txToCw.get(transaction5.getHash().getSubHash()).intValue());
+                2, txToCw.get(IotaUtils.getSubHash(transaction5.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                2, txToCw.get(transaction4.getHash().getSubHash()).intValue());
+                2, txToCw.get(IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                3, txToCw.get(transaction3.getHash().getSubHash()).intValue());
+                3, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(transaction2.getHash().getSubHash()).intValue());
+                3, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                1, txToCw.get(transaction1.getHash().getSubHash()).intValue());
+                1, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                7, txToCw.get(transaction.getHash().getSubHash()).intValue());
+                7, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
     }
 
     @Test
@@ -249,7 +253,8 @@ public class TipsManagerTest {
             log.debug(String.format("tx %.4s has expected weight of %d", hash, weight.size()));
             Assert.assertEquals(
                     "new calculation weight is not as expected for hash " + hash,
-                    weight.size(), txToCw.get(hash.getSubHash()).intValue());
+                    weight.size(), txToCw.get(IotaUtils.getSubHash(hash, TipsManager.SUBHASH_LENGTH))
+                            .intValue());
         });
     }
 
@@ -279,11 +284,16 @@ public class TipsManagerTest {
 
         log.info(cumulativeWeight.toString());
         String msg = "Cumulative weight is wrong for tx";
-        Assert.assertEquals(msg + 4, 1, cumulativeWeight.get(transaction4.getHash().getSubHash()).intValue());
-        Assert.assertEquals(msg + 3, 1, cumulativeWeight.get(transaction3.getHash().getSubHash()).intValue());
-        Assert.assertEquals(msg + 2, 1, cumulativeWeight.get(transaction2.getHash().getSubHash()).intValue());
-        Assert.assertEquals(msg + 1, 2, cumulativeWeight.get(transaction1.getHash().getSubHash()).intValue());
-        Assert.assertEquals(msg + 0, 3, cumulativeWeight.get(transaction.getHash().getSubHash()).intValue());
+        Assert.assertEquals(msg + 4, 1, cumulativeWeight.get(
+                IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+        Assert.assertEquals(msg + 3, 1, cumulativeWeight.get(
+                IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+        Assert.assertEquals(msg + 2, 1, cumulativeWeight.get(
+                IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+        Assert.assertEquals(msg + 1, 2, cumulativeWeight.get(
+                IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+        Assert.assertEquals(msg + 0, 3, cumulativeWeight.get(
+                IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
     }
 
     //    @Test

--- a/src/test/java/com/iota/iri/service/TipsManagerTest.java
+++ b/src/test/java/com/iota/iri/service/TipsManagerTest.java
@@ -19,6 +19,7 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
 import java.util.*;
 
 import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionHash;
@@ -90,19 +91,19 @@ public class TipsManagerTest {
         transaction2.store(tangle);
         transaction3.store(tangle);
         transaction4.store(tangle);
-        Map<Hash, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
+        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
                 transaction.getHash(), false, new HashSet<>());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                1, txToCw.get(transaction4.getHash()).intValue());
+                1, txToCw.get(transaction4.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                2, txToCw.get(transaction3.getHash()).intValue());
+                2, txToCw.get(transaction3.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(transaction2.getHash()).intValue());
+                3, txToCw.get(transaction2.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                4, txToCw.get(transaction1.getHash()).intValue());
+                4, txToCw.get(transaction1.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                5, txToCw.get(transaction.getHash()).intValue());
+                5, txToCw.get(transaction.getHash().getSubHash()).intValue());
     }
 
     @Test
@@ -121,17 +122,17 @@ public class TipsManagerTest {
         transaction3.store(tangle);
         log.debug("printing transaction in diamond shape \n                      {} \n{}  {}\n                      {}",
                 transaction.getHash(), transaction1.getHash(), transaction2.getHash(), transaction3.getHash());
-        Map<Hash, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
+        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
                 transaction.getHash(), false, new HashSet<>());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                1, txToCw.get(transaction3.getHash()).intValue());
+                1, txToCw.get(transaction3.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                2, txToCw.get(transaction1.getHash()).intValue());
+                2, txToCw.get(transaction1.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                2, txToCw.get(transaction2.getHash()).intValue());
+                2, txToCw.get(transaction2.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                4, txToCw.get(transaction.getHash()).intValue());
+                4, txToCw.get(transaction.getHash().getSubHash()).intValue());
     }
 
     @Test
@@ -151,20 +152,24 @@ public class TipsManagerTest {
         transaction2.store(tangle);
         transaction3.store(tangle);
         transaction4.store(tangle);
-        Map<Hash, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
+
+        log.info(String.format("Linear ordered hashes from tip %.4s, %.4s, %.4s, %.4s, %.4s", transaction4.getHash(),
+                transaction3.getHash(), transaction2.getHash(), transaction1.getHash(), transaction.getHash()));
+
+        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
                 transaction.getHash(), false, new HashSet<>());
 
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                1, txToCw.get(transaction4.getHash()).intValue());
+                1, txToCw.get(transaction4.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                2, txToCw.get(transaction3.getHash()).intValue());
+                2, txToCw.get(transaction3.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(transaction2.getHash()).intValue());
+                3, txToCw.get(transaction2.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                4, txToCw.get(transaction1.getHash()).intValue());
+                4, txToCw.get(transaction1.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                5, txToCw.get(transaction.getHash()).intValue());
+                5, txToCw.get(transaction.getHash().getSubHash()).intValue());
     }
 
     @Test
@@ -197,23 +202,23 @@ public class TipsManagerTest {
                 transaction.getHash(), transaction1.getHash(), transaction2.getHash(), transaction3.getHash(),
                 transaction4, transaction5, transaction6);
 
-        Map<Hash, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
+        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
                 transaction.getHash(), false, new HashSet<>());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 6),
-                1, txToCw.get(transaction6.getHash()).intValue());
+                1, txToCw.get(transaction6.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 5),
-                2, txToCw.get(transaction5.getHash()).intValue());
+                2, txToCw.get(transaction5.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                2, txToCw.get(transaction4.getHash()).intValue());
+                2, txToCw.get(transaction4.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                3, txToCw.get(transaction3.getHash()).intValue());
+                3, txToCw.get(transaction3.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(transaction2.getHash()).intValue());
+                3, txToCw.get(transaction2.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                1, txToCw.get(transaction1.getHash()).intValue());
+                1, txToCw.get(transaction1.getHash().getSubHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                7, txToCw.get(transaction.getHash()).intValue());
+                7, txToCw.get(transaction.getHash().getSubHash()).intValue());
     }
 
     @Test
@@ -236,7 +241,7 @@ public class TipsManagerTest {
         }
         Map<Hash, Set<Hash>> ratings = new HashMap<>();
         updateApproversRecursively(hashes[0], ratings, new HashSet<>());
-        Map<Hash, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
+        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
                 hashes[0], false, new HashSet<>());
 
         Assert.assertEquals("missing txs from new calculation", ratings.size(), txToCw.size());
@@ -244,7 +249,7 @@ public class TipsManagerTest {
             log.debug(String.format("tx %.4s has expected weight of %d", hash, weight.size()));
             Assert.assertEquals(
                     "new calculation weight is not as expected for hash " + hash,
-                    weight.size(), txToCw.get(hash).intValue());
+                    weight.size(), txToCw.get(hash.getSubHash()).intValue());
         });
     }
 
@@ -269,16 +274,16 @@ public class TipsManagerTest {
         transaction3.store(tangle);
         transaction4.store(tangle);
 
-        Map<Hash, Integer> cumulativeWeight = tipsManager.calculateCumulativeWeight(approvedHashes,
+        Map<Buffer, Integer> cumulativeWeight = tipsManager.calculateCumulativeWeight(approvedHashes,
                 transaction.getHash(), true, new HashSet<>());
 
         log.info(cumulativeWeight.toString());
         String msg = "Cumulative weight is wrong for tx";
-        Assert.assertEquals(msg + 4, 1, cumulativeWeight.get(transaction4.getHash()).intValue());
-        Assert.assertEquals(msg + 3, 1, cumulativeWeight.get(transaction3.getHash()).intValue());
-        Assert.assertEquals(msg + 2, 1, cumulativeWeight.get(transaction2.getHash()).intValue());
-        Assert.assertEquals(msg + 1, 2, cumulativeWeight.get(transaction1.getHash()).intValue());
-        Assert.assertEquals(msg + 0, 3, cumulativeWeight.get(transaction.getHash()).intValue());
+        Assert.assertEquals(msg + 4, 1, cumulativeWeight.get(transaction4.getHash().getSubHash()).intValue());
+        Assert.assertEquals(msg + 3, 1, cumulativeWeight.get(transaction3.getHash().getSubHash()).intValue());
+        Assert.assertEquals(msg + 2, 1, cumulativeWeight.get(transaction2.getHash().getSubHash()).intValue());
+        Assert.assertEquals(msg + 1, 2, cumulativeWeight.get(transaction1.getHash().getSubHash()).intValue());
+        Assert.assertEquals(msg + 0, 3, cumulativeWeight.get(transaction.getHash().getSubHash()).intValue());
     }
 
     //    @Test

--- a/src/test/java/com/iota/iri/utils/BoundedHashSetTest.java
+++ b/src/test/java/com/iota/iri/utils/BoundedHashSetTest.java
@@ -1,0 +1,39 @@
+package com.iota.iri.utils;
+
+import com.iota.iri.utils.collections.impl.BoundedHashSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class BoundedHashSetTest {
+
+    @Test
+    public void createBoundedHashSetWithCollectionTest() {
+        List<Integer> list = Arrays.asList(1, 2 ,3, 4, 5, 6);
+        BoundedHashSet<Integer> boundedSet = new BoundedHashSet<>(list, 4);
+        Assert.assertEquals(new HashSet<>(Arrays.asList(1, 2, 3, 4)), boundedSet);
+    }
+
+    @Test
+    public void testAdd() {
+        BoundedHashSet<Integer> boundedSet = new BoundedHashSet<>(3);
+        Assert.assertTrue("can't add to unfull set", boundedSet.add(1));
+        Assert.assertTrue("can't add to unfull set", boundedSet.add(2));
+        Assert.assertTrue("can't add to unfull set", boundedSet.add(3));
+        Assert.assertFalse("can add to full set", boundedSet.add(4));
+        Assert.assertEquals("bounded set doesn't have expected contents",
+                new HashSet<>(Arrays.asList(1, 2, 3)), boundedSet);
+    }
+
+    @Test
+    public void testAddAll() {
+        BoundedHashSet<Integer> boundedSet = new BoundedHashSet<>(3);
+        Assert.assertTrue("set did not change after add", boundedSet.addAll(Arrays.asList(5, 6, 7, 8, 9)));
+        Assert.assertEquals("bounded set doesn't have expected contents",
+                new HashSet<>(Arrays.asList(5, 6, 7)), boundedSet);
+    }
+
+}


### PR DESCRIPTION
Context: The whitepaper describes a need to perform cumulative weight calculations on the transactions in order to perform the MCMC algorithm.

Problem: There are two versions of the algorithm implemented in the code:

In use - a time and memory efficient algorithm that performs a different calculation than the one described in the WP. Each transaction sums the weight of its direct ancestors and adds itself. This way indirect ancestors may be counted more than once. This may cause weight to increase exponentially.

Solution: A space time efficient algorithm similar to algo (2). If you traverse the subtangle in topological order, you can dispose of sets you have used. See https://github.com/alongalky/iota-docs/blob/master/cumulative.md.